### PR TITLE
chore: skip tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
   email: false
 node_js:
   - "6"
+script:
+  - echo NO TESTS
 deploy:
   skip_cleanup: true
   provider: script


### PR DESCRIPTION
Skipping tests on travis as we use it for deployment only