### PR TITLE
chore: remove "I'm back online message"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,6 @@ function setup(callback) {
   bot.started(data => {
     debug('started');
     bot.self = { id: data.self.id, name: data.self.name };
-    data.channels.filter(_ => _.is_member).map(channel => {
-      reply({ channel: channel.id }, `:wave: hey, I'm back online`);
-    });
     console.log('connected', bot.self);
     if (callback) {
       callback(bot);


### PR DESCRIPTION
retrobot send a message every time it is online,
sometimes the retrobot pod is being restarted
and it sends a message to the relevant slack channels.

this change can really reduce the slack noise for those channels.