### PR TITLE
chore: codeowners -> infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/infrastructure


### PR DESCRIPTION
This is a back-office-y service that's not being used by any customers, but it's still running in the cluster, so needs love.